### PR TITLE
Refactor release workflow to use stable cargo-dist installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,7 @@
 name: Release (cargo-dist)
+permissions:
+  contents: write
+  id-token: write
 
 on:
   push:
@@ -20,10 +23,12 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-dist
-        uses: cargo-dist/action-setup-cargo-dist@v1
-
-      - name: Check cargo-dist version
-        run: cargo-dist --version
+        shell: bash
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.0/cargo-dist-installer.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          which dist
+          dist --version
 
       - name: Setup Node for UI build
         uses: actions/setup-node@v4
@@ -41,7 +46,7 @@ jobs:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: -Cstrip=symbols
         run: |
-          cargo dist build
+          dist build --output-format=json
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -54,13 +59,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Download dist artifacts
         uses: actions/download-artifact@v4
         with:
           path: dist
 
-      - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            dist/**
+      - name: Create GitHub Release
+        env:
+          RELEASE_COMMIT: ${{ github.sha }}
+        run: |
+          gh release create "${GITHUB_REF##*/}" --target "$RELEASE_COMMIT" --notes "Release $GITHUB_REF" dist/*


### PR DESCRIPTION
- Use the official cargo-dist installer script instead of manual setup.
- Ensure cross-platform builds and artifact uploads.
- Improves workflow stability, reproducibility, and release automation.
